### PR TITLE
Add target locking while driving

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2024/Robot.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/Robot.java
@@ -6,6 +6,7 @@ package org.jmhsrobotics.frc2024;
 
 import org.jmhsrobotics.warcore.util.BuildDataLogger;
 
+import edu.wpi.first.hal.AllianceStationID;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
@@ -111,5 +112,6 @@ public class Robot extends TimedRobot implements Logged {
 	public void simulationInit() {
 		DriverStationSim.setDsAttached(true);
 		DriverStationSim.setEnabled(true);
+		DriverStationSim.setAllianceStationId(AllianceStationID.Blue1);
 	}
 }

--- a/src/main/java/org/jmhsrobotics/frc2024/RobotContainer.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/RobotContainer.java
@@ -71,7 +71,8 @@ public class RobotContainer implements Logged {
 		}
 		// swboard.setControlBoard(new CompControl());
 		this.control = swboard;
-		this.driveSubsystem.setDefaultCommand(new DriveCommand(this.driveSubsystem, this.control));
+		this.driveSubsystem
+				.setDefaultCommand(new DriveCommand(this.driveSubsystem, this.visionSubsystem, this.control));
 
 		this.intakeSubsystem.setDefaultCommand(new DefaultIntakeCommand(this.intakeSubsystem, this.shooterSubsystem));
 

--- a/src/main/java/org/jmhsrobotics/frc2024/subsystems/arm/commands/PrepareShot.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/subsystems/arm/commands/PrepareShot.java
@@ -2,7 +2,6 @@ package org.jmhsrobotics.frc2024.subsystems.arm.commands;
 
 import org.jmhsrobotics.frc2024.subsystems.arm.ArmPIDSubsystem;
 import org.jmhsrobotics.frc2024.subsystems.drive.DriveSubsystem;
-import org.jmhsrobotics.frc2024.subsystems.drive.commands.LockSpeaker;
 import org.jmhsrobotics.frc2024.subsystems.shooter.ShooterSubsystem;
 import org.jmhsrobotics.frc2024.subsystems.shooter.commands.ShootOpenLoopCommand;
 import org.jmhsrobotics.frc2024.subsystems.vision.VisionSubsystem;
@@ -19,8 +18,7 @@ public class PrepareShot extends ParallelCommandGroup {
 		this.arm = arm;
 		this.shooter = shooter;
 		this.vision = vision;
-		addCommands(new LockSpeaker(drive, vision), new ArmVision(arm, vision, drive),
-				new ShootOpenLoopCommand(12, shooter));
+		addCommands(new ArmVision(arm, vision, drive), new ShootOpenLoopCommand(12, shooter));
 	}
 
 }


### PR DESCRIPTION
Allows drivers to target lock and still allows them to drive. When used with prepare shot the everything spins up/sets up as it should.

If we plan on using this in match we should remap the buttons to something easer to press.