### PR TITLE
Optimize Can bus frames for Rev

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2024/subsystems/arm/ArmPIDSubsystem.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/subsystems/arm/ArmPIDSubsystem.java
@@ -3,6 +3,7 @@ package org.jmhsrobotics.frc2024.subsystems.arm;
 import org.jmhsrobotics.frc2024.Constants;
 
 import com.revrobotics.CANSparkLowLevel.MotorType;
+import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.SparkAbsoluteEncoder.Type;
 import com.revrobotics.SparkLimitSwitch;
@@ -61,6 +62,34 @@ public class ArmPIDSubsystem extends SubsystemBase implements Logged {
 			tempAngle -= 360;
 		}
 		relativeEncoder.setPosition(tempAngle);
+
+		// optimize Can Traffic
+		// armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 10); // applied
+		// output, faults, sticky faults, isfollower - 10ms
+		// armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 20); // Velocity,
+		// temp, voltage,current - 20ms
+		// armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 20); // Rel pos -
+		// 20ms
+		armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 20); // Duty Cycle Absolute Encoder Position/ angle -
+																		// 200ms
+		armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder Velocity/
+																		// freequency - 200ms
+		armPivot.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
+
+		// optimize Can Traffic
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 20); // applied output, faults, sticky faults,
+																		// isfollower - 10ms
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 200); // Velocity, temp, voltage,current - 20ms
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 200); // Rel pos - 20ms
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 65535); // Duty Cycle Absolute Encoder Position/ angle
+																			// - 200ms
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder Velocity/
+																			// freequency - 200ms
+		armHelper.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
 
 		// armPivot.setSoftLimit(SoftLimitDirection.kReverse, 2);
 		// armPivot.setSoftLimit(SoftLimitDirection.kForward, 120);

--- a/src/main/java/org/jmhsrobotics/frc2024/subsystems/climber/ClimberSubsystem.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/subsystems/climber/ClimberSubsystem.java
@@ -7,6 +7,7 @@ import com.revrobotics.RelativeEncoder;
 
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
+import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import monologue.Logged;
@@ -29,6 +30,32 @@ public class ClimberSubsystem extends SubsystemBase implements Logged {
 		rightClimber.setIdleMode(IdleMode.kBrake);
 		leftClimberEncoder.setPositionConversionFactor((5.0 * 4.0) / 100.0); // 20:1 gear reduction
 		rightClimberEncoder.setPositionConversionFactor((5.0 * 4.0) / 100.0); // 20:1 gear reduction
+
+		// optimize Can Traffic
+		// leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 10); // applied
+		// output, faults, sticky faults, isfollower - 10ms
+		leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 200); // Velocity, temp, voltage,current - 20ms
+		leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 200); // Rel pos - 20ms
+		leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 65535); // Duty Cycle Absolute Encoder Position/
+																			// angle - 200ms
+		leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder Velocity/
+																			// freequency - 200ms
+		leftClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
+
+		// optimize Can Traffic
+		// rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 10); // applied
+		// output, faults, sticky faults, isfollower - 10ms
+		rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 200); // Velocity, temp, voltage,current - 20ms
+		rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 200); // Rel pos - 20ms
+		rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 65535); // Duty Cycle Absolute Encoder Position/
+																			// angle - 200ms
+		rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder Velocity/
+																			// freequency - 200ms
+		rightClimber.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
 
 		// climber.setSoftLimit(SoftLimitDirection.kReverse, 10);
 		// climber.setSoftLimit(SoftLimitDirection.kForward, 40);

--- a/src/main/java/org/jmhsrobotics/frc2024/subsystems/drive/swerve/MAXSwerveModule.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/subsystems/drive/swerve/MAXSwerveModule.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkLowLevel.MotorType;
+import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
 import com.revrobotics.SparkAbsoluteEncoder.Type;
 import com.revrobotics.SparkPIDController;
 
@@ -106,6 +107,36 @@ public class MAXSwerveModule implements ISwerveModule {
 		m_turningSparkMax.setIdleMode(Constants.ModuleConstants.kTurningMotorIdleMode);
 		m_drivingSparkMax.setSmartCurrentLimit(Constants.ModuleConstants.kDrivingMotorCurrentLimit);
 		m_turningSparkMax.setSmartCurrentLimit(Constants.ModuleConstants.kTurningMotorCurrentLimit);
+
+		// optimize Can Traffic
+		// m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 10); //
+		// applied output, faults, sticky faults, isfollower - 10ms
+		// m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 20); //
+		// Velocity, temp, voltage,current - 20ms
+		// m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 20); // Rel
+		// pos - 20ms
+		m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 65535); // Duty Cycle Absolute Encoder
+																					// Position/ angle - 200ms
+		m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder
+																					// Velocity/ freequency - 200ms
+		m_drivingSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
+
+		// optimize Can Traffic
+		// m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 10); //
+		// applied output, faults, sticky faults, isfollower - 10ms
+		// m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 20); //
+		// Velocity, temp, voltage,current - 20ms
+		// m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 20); // Rel
+		// pos - 20ms
+		m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		// m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 200); //
+		// Duty Cycle Absolute Encoder Position/ angle - 200ms
+		m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder
+																					// Velocity/ freequency - 200ms
+		m_turningSparkMax.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
 
 		// Save the SPARK MAX configurations. If a SPARK MAX browns out during
 		// operation, it will maintain the above configurations.

--- a/src/main/java/org/jmhsrobotics/frc2024/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/subsystems/intake/IntakeSubsystem.java
@@ -5,6 +5,7 @@ import org.jmhsrobotics.warcore.rev.RevEncoderSimWrapper;
 
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
+import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
 import com.playingwithfusion.TimeOfFlight;
 import com.playingwithfusion.TimeOfFlight.RangingMode;
 import com.revrobotics.CANSparkMax;
@@ -34,6 +35,19 @@ public class IntakeSubsystem extends SubsystemBase implements Logged {
 
 		this.lowerSensor.setRangingMode(RangingMode.Short, 24);
 		this.upperSensor.setRangingMode(RangingMode.Short, 24);
+
+		// optimize Can Traffic
+		// intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 0); // applied
+		// output, faults, sticky faults, isfollower - 10ms
+		intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 200); // Velocity, temp, voltage,current - 20ms
+		intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 200); // Rel pos - 20ms
+		intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 65535); // Duty Cycle Absolute Encoder Position/
+																			// angle - 200ms
+		intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder Velocity/
+																			// freequency - 200ms
+		intakeMotor.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
 
 		if (RobotBase.isSimulation()) {
 			simInit();

--- a/src/main/java/org/jmhsrobotics/frc2024/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/org/jmhsrobotics/frc2024/subsystems/shooter/ShooterSubsystem.java
@@ -7,6 +7,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
+import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.BangBangController;
@@ -52,6 +53,34 @@ public class ShooterSubsystem extends SubsystemBase implements Logged {
 		this.lowerPID.setTolerance(50);
 
 		initializeMotors();
+
+		// optimize Can Traffic
+		// topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 10); // applied
+		// output, faults, sticky faults, isfollower - 10ms
+		// topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 20); // Velocity,
+		// temp, voltage,current - 20ms
+		topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 200); // Rel pos - 20ms
+		topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 65535); // Duty Cycle Absolute Encoder Position/
+																			// angle - 200ms
+		topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder Velocity/
+																			// freequency - 200ms
+		topFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
+
+		// optimize Can Traffic
+		// bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus0, 10); // applied
+		// output, faults, sticky faults, isfollower - 10ms
+		// bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus1, 20); //
+		// Velocity, temp, voltage,current - 20ms
+		bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus2, 200); // Rel pos - 20ms
+		bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus3, 65535); // Analog sensor volts, vel, acc - 50ms
+		bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus4, 65535); // Alternate Encoder Vel/pos - 20ms
+		bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus5, 65535); // Duty Cycle Absolute Encoder Position/
+																				// angle - 200ms
+		bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus6, 65535); // Duty Cycle Absolute Encoder Velocity/
+																				// freequency - 200ms
+		bottomFlywheel.setPeriodicFramePeriod(PeriodicFrame.kStatus7, 65535); // I accumm
 		if (RobotBase.isSimulation()) {
 			initSim();
 		}


### PR DESCRIPTION
Modify Rev Can bus Frame timing.
Must be tested first. Makes sure it makes a reduction in can traffic as well as does not break any part of the robot.