### PR TITLE
Update to revlib-2024.2.4

### DIFF
--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2024.2.0",
+    "version": "2024.2.4",
     "frcYear": "2024",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2024.2.0"
+            "version": "2024.2.4"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.2.0",
+            "version": "2024.2.4",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2024.2.0",
+            "version": "2024.2.4",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -55,7 +55,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.2.0",
+            "version": "2024.2.4",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
Possible Fix with can issues we where having. Be very careful updating, we need to make sure to test and validate this fully.

Version2024.2.4
Changes to C++ and Java
Increases the default timeout to wait for a periodic status from 2*framePeriodMs to 500ms.

Reduces possibility of large, inaccurate jumps in data occurring when retrieving from status frames.

Reduces amount of "timed out while waiting for periodic status X" errors in driver station.

Adds setPeriodicFrameTimeout() to configure the CAN timeout for periodic status frames. [See code docs for more information.](https://docs.revrobotics.com/ion-control-system/sw/revlib)

Improves reliability of RTR CAN frames such as setting parameters and other commands that expect a response from the device.

Adds mechanism to retry requests if sending the request or receiving the response failed. The default value for maximum number of retries is 5.

Adds setCANMaxRetries() to configure the value for maximum number of retries. [See code docs for more information.](https://docs.revrobotics.com/ion-control-system/sw/revlib)

Fixes undefined behavior when SPARK motor controller information cannot be retrieved during initialization.

Version 2024.2.3
Changes to Java
Fixes issue introduced in v2024.2.2 where calling getEncoder() multiple times can cause a fatal exception in certain circumstances.

Changes to C++ and Java
Removes dynamic check for SPARK model when calling getEncoder(), causing unnecessary CAN traffic. 

Moves zero argument CANSparkBase.getEncoder() to CANSparkMax and CANSparkFlex subclasses to determine default encoder values.

Version 2024.2.2
Changes to C++ and Java
Fixes issue where configuring the velocity filter for the default relative encoder of a SPARK Flex would not set the correct parameters.

Changes to Java
Improves memory allocation performance.

Version 2024.2.1
Changes to C++ and Java
Changes behavior of SPARK Flex and MAX initialization errors to throw exceptions rather than terminating the robot program.

Fixes issue where initializing a SPARK Flex or MAX in brushed mode while the device is disconnected from the CAN bus causes the robot program to terminate.

Fixes issue where initializing a SPARK Flex or MAX in brushed mode causes robot simulation to terminate.

Fixes warning about using the wrong class for a SPARK Flex or MAX during robot simulation.

Changes to C++
Fixes ambiguous overload error when no parameters are supplied when calling GetAnalogSensor().

Fixes ambiguous overload error when no parameters are supplied when calling GetEncoder().